### PR TITLE
Ensure url parameters begin with characters

### DIFF
--- a/src/parseUrl.js
+++ b/src/parseUrl.js
@@ -1,5 +1,5 @@
 export default function parseUrl(url, params) {
-  return url.replace(/(:)([A-Za-z0-9]*)/g, (match, $1, $2) => {
+  return url.replace(/(:)([A-Za-z][A-Za-z0-9]*)/g, (match, $1, $2) => {
     const paramType  = typeof params[$2];
     if (paramType !== 'string' && paramType !== 'number') {
       throw new Error(`Param ${$2} from url ${url}, not found in params object`);


### PR DESCRIPTION
This increases tolerance for absolute urls to external services like:

    http://other-service:8000/api/product/:id

Mandating that the character begins with at least one alphabetic character
avoids parseUrl from trying to dereference the ":" before the double slash
and the port number which causes an error.